### PR TITLE
Add pull step

### DIFF
--- a/master-solution-branch-splitter/README.md
+++ b/master-solution-branch-splitter/README.md
@@ -56,11 +56,13 @@ pip install gitpython
 
 When setting up the alias you may also need to update your `.bash_profile` by closing and reopening terminal or running `source ~/.bash_profile`
 
+**Merge Conflicts:** During execution the script will attempt to pull the remote `master` and `solution` branches to merge into your local `master` and `solution` respectively. It then creates the new notebook, commits and pushes. The pull step is to avoid the error `Updates were rejected because the remote contains work that you do not have locally` when there were commits added to remote that you do not have locally. **If pulling results in a merge conflict, fix manually and then re-run `dscreate`** (Fix in any way that results in no conflict, your local state isn't especially important because the script will be creating a new notebook anyway).
+
 ## Style Guide
 * [Curriculm Branch Style Guide](https://docs.google.com/document/d/1YpJN9S1kzoObMyIE02OszgHdlqhRP6ktgW5S74UzbNk/edit)
 
 ## Note on Additional Files (not notebook or readme)
-Any additional files added to `curriculum` and committed will be transferred to both `master` & `solution` branches when the script is run.  If one specific branch, but not the other, needs (or doesn't need) a file, it will have to be added (or removed) to that specific branch manually. 
+Any additional files added to `curriculum` and committed will be transferred to both `master` & `solution` branches when the script is run.  If one specific branch, but not the other, needs (or doesn't need) a file, it will have to be added (or removed) to that specific branch manually.
 
 _Note: The `index_files` directory of images is deleted and then recreated when the notebook is converted to markdown on both `master` & `solution` branches each time the script runs._
 

--- a/master-solution-branch-splitter/index.py
+++ b/master-solution-branch-splitter/index.py
@@ -93,6 +93,9 @@ def sync_branch(repo, branch, notebook, msg="Curriculum Auto-Sync"):
         branch_exists = False
 
     if branch_exists:
+        # pull any changes from remote local does not have to avoid pushing errors
+        repo.git.pull("origin", branch)
+
         # get all files from curriculum branch and put onto this branch,
         # (the notebook and readme will be overwritten in the subsequent steps)
         # Interesting use of the `checkout` command


### PR DESCRIPTION
Before generating new noteboook -> committing -> pushing, add step to pull remote changes.
This accounts for the scenario when you previously have the repo cloned locally, someone else has since made changes to the remote, then you are updating.

Added a troubleshooting note for what to do in the case of merge conflicts (resolve & run again).  If that sounds clear, give me thumbs up and i'll merge this in!